### PR TITLE
reverseproxy-waf: fix to use standard logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ cd into the directory containing the locally cloned git files, and run a git pul
 
 ```bash
 cd /srv/<my-website>/<host>/zorg-docker
-git pull --depth 1 --rebase
+git pull --rebase
 ```
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,7 +191,7 @@ services:
             - TZ=${TIMEZONE:-Europe/Zurich}
             - SERVER_NAME=${DOMAINNAME:-modsec-waf}
             - BACKEND=http://website:${HTTP_PORT:-80}
-            - ERRORLOG=/var/log/modsecurity/modsec_error.log
+            #- ERRORLOG=/var/log/modsecurity/modsec_error.log : DISABLED - default: /proc/self/fd/2
             - APACHE_ALWAYS_TLS_REDIRECT=true
             - PROXY_PRESERVE_HOST=on
             - PROXY_ERROR_OVERRIDE=off
@@ -199,7 +199,7 @@ services:
             # -=[ modsec specific ]=-
             - MODSEC_AUDIT_LOG_FORMAT=JSON
             - MODSEC_UPLOAD_KEEP_FILES=Off
-            - MODSEC_AUDIT_LOG=/var/log/modsecurity/modsec_audit.log
+            #- MODSEC_AUDIT_LOG=/var/log/modsecurity/modsec_audit.log : DISABLED - default: /dev/stdout
             # -=[ CRS specific ]=-
             - ANOMALY_INBOUND=5
             - ANOMALY_OUTBOUND=5


### PR DESCRIPTION
Should resolve issue

```
AH00526: Syntax error on line 24 of /etc/modsecurity.d/modsecurity.conf:
ModSecurity: Failed to open the audit log file: /var/log/modsecurity/modsec_audit.log
```