### PR TITLE
reverseproxy: no TLS/SSL termination for SMTP :587

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,6 +399,7 @@ services:
             - "traefik.enable=true"
             # -=[ SMTP with STARTTLS (587) ]=-
             - "traefik.tcp.routers.mailsmtp.tls=true"
+            - "traefik.tcp.routers.mailsmtp.tls.passthrough=true"
             - "traefik.tcp.routers.mailsmtp.service=smtp-tcp-service"
             - "traefik.tcp.routers.mailsmtp.entrypoints=smtp-tcp"
             - "traefik.tcp.routers.mailsmtp.rule=HostSNI(`${MAILSERVER_HOST:+${MAILSERVER_HOST}.${DOMAINNAME}}`)"

--- a/resources/website/cron/README.md
+++ b/resources/website/cron/README.md
@@ -6,9 +6,25 @@ Zum Beispiel: Daily Pic setzen, Daily Quote setzen, Gravater Userimages cachen, 
 ### Cron jobs speichern
 Über das `crontab` werden die verschiedenen Cron jobs anhand deren Wiederholungsrate festgelegt:
 
+> [!TIP]
+> Die folgende Job Konfiguration führt ein PHP script innerhalb des `zorg-website` Docker Containers aus.
+> Daher ist auch der `wwwroot`-Parameter "aus Sicht innerhalb des Containers" zu definieren.
+
 ```
-$ sudo crontab -e
- *      15 7 * * * php -f /path/to/cron/[file].php > /path/wher/to/log/cron_[cadence].log
+$ su <user>
+$ crontab -e
+    3 7 * * * docker exec -u www-data zorg-website /usr/local/bin/php -f /var/www/cron/tag.php "wwwroot=/var/www/html/public/" >> /proc/1/fd/1 2>&1 # Daily
+```
+
+> [!NOTE]
+> Zum Vergleich: im folgenden ein corontab Job der DIREKT innerhalb eines Docker Containers mit php & cron Kapazitäten ausführt:
+
+```
+$ su <user>
+$ docker exec -it zorg-website /bin/bash
+
+    crontab -e
+        3 7 * * * /usr/local/bin/php -f /var/www/cron/tag.php wwwroot=/var/www/html/public/ >> /proc/1/fd/1 2>&1
 ```
 
 ## Minutely


### PR DESCRIPTION
Do not terminate the TLS handshake on the `reverseproxy`, but use passthrough to the `postfix-smtp` service on the STARTTLS port.