### PR TITLE
Adds new Docker Service «Adminer»

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,7 +174,6 @@ PHP_VERSION=7.4
 
 # 💽 MariaDB Database
 MARIADB_VERSION=latest
-MARIADB_HOST=db
 MARIADB_PORT=3306
 # Locally, you may disable ROOT_PASSWORD using 'yes'
 MARIADB_DISABLE_ROOT_PASSWORD=no
@@ -184,6 +183,12 @@ DATABASE_USER=
 DATABASE_PASSWORD=
 # [💡] Locally, and for debugging, configure: --innodb_monitor_enable=all AND reduce --max-connections=150
 MARIADB_MYSQLD_OPTIONS="--default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci --explicit_defaults_for_timestamp --max-connections=3840"
+
+# 🎛️ adminer Database-Manager
+DBMANAGER_VERSION=latest
+DBMANAGER_HOST=db
+DBMANAGER_DESIGN=dracula
+DBMANAGER_PLUGINS="tables-filter tinymce"
 
 # 📧 Mail Server (SMTP)
 MAILSERVER_HOST=mail
@@ -233,4 +238,4 @@ STOCKTICKER_TELEGRAM_BOT_CHATID=
 #===========================================================
 # 🚨 This MUST come *AFTER* all Hostnames have been defined!
 #===========================================================
-SELFSIGNED_CERT_HOSTS="${DASHBOARD_HOST:+${DASHBOARD_HOST}.${DOMAINNAME}} ${MARIADB_HOST:+${MARIADB_HOST}.${DOMAINNAME}} ${MAILSERVER_HOST:+${MAILSERVER_HOST}.${DOMAINNAME}} ${MAILSERVER_HOST_INTERNAL:+${MAILSERVER_HOST_INTERNAL}.${DOMAINNAME}} ${IRC_HOST:+${IRC_HOST}.${DOMAINNAME}} ${IRC_SERVICES_HOST:+${IRC_SERVICES_HOST}.${DOMAINNAME}} ${KEEPASS_HOST:+${KEEPASS_HOST}.${DOMAINNAME}}"
+SELFSIGNED_CERT_HOSTS="${DASHBOARD_HOST:+${DASHBOARD_HOST}.${DOMAINNAME}} ${DBMANAGER_HOST:+${DBMANAGER_HOST}.${DOMAINNAME}} ${MAILSERVER_HOST:+${MAILSERVER_HOST}.${DOMAINNAME}} ${MAILSERVER_HOST_INTERNAL:+${MAILSERVER_HOST_INTERNAL}.${DOMAINNAME}} ${IRC_HOST:+${IRC_HOST}.${DOMAINNAME}} ${IRC_SERVICES_HOST:+${IRC_SERVICES_HOST}.${DOMAINNAME}} ${KEEPASS_HOST:+${KEEPASS_HOST}.${DOMAINNAME}}"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Here's an overview of the underlaying Docker images used for the Docker Services
 | `reverseproxy`<br>+ `owasp-coraza-waf@file` | `traefik`<br>`coraza-http-wasm-traefik` | [Docs](https://doc.traefik.io/traefik/)<br>[GitHub](https://github.com/jcchavezs/coraza-http-wasm-traefik) |
 | `website`          | `php`                     | [Docker Hub](https://hub.docker.com/_/php) |
 | `db`               | `mariadb`                 | [Docs](https://mariadb.com/kb/en/mariadb-server-docker-official-image-environment-variables/) |
+| `db-manager`       | `adminer`                 | [Docs](https://hub.docker.com/_/adminer/#how-to-use-this-image) |
 | `postfix-smtp`     | `mailserver/docker-mailserver` | [Docs](https://docker-mailserver.github.io/docker-mailserver/) |
 | `irc`              | `c0dy/unrealircd-anope`   | [Docker Hub](https://hub.docker.com/r/c0dy/unrealircd-anope) |
 | `irc-quizbot`      | `python:3.12-slim`        | [GitHub](https://github.com/zorgch/irc-quizbot) |
@@ -466,7 +467,7 @@ Some single services have their own profile, in order to prevent them from start
 | `all`          | All general services          | `--profile all`                       |
 | `setup`        | `sslcerts` `postfix-smtp`     | `--profile setup`                     |
 | `status`       | `servicealerts` `dashboard` `reverseproxy`      | `--profile status`  |
-| `webserver`    | `servicealerts` `dashboard` `reverseproxy` `website` `db` `postfix-smtp` | `--profile webserver` |
+| `webserver`    | `servicealerts` `dashboard` `reverseproxy` `website` `db` `db-manager` `postfix-smtp` | `--profile webserver` |
 | `mailserver`   | `servicealerts` `dashboard` `reverseproxy` `postfix-smtp` | `--profile mailserver` |
 | `irc`          | `servicealerts` `dashboard` `irc` `irc-quizbot` | `--profile irc`     |
 | `keepass`      | `servicealerts` `dashboard` `sftp`              | `--profile keepass` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,10 @@ services:
             - "telegram-notifier.topic-id=${TELEGRAM_BOT_SERVICEALERTS_CHATTOPICID:-}"
             # -=[ traefik Reverse Proxy : routing CONDITIONAL ]=-
             - "traefik.enable=${REVERSEPROXY_DASHBOARD:-false}"
-            - ${REVERSEPROXY_DASHBOARD:+traefik.http.routers.api.service=api@internal}
+            - ${REVERSEPROXY_DASHBOARD:+traefik.http.routers.api.tls=true}
+            - ${REVERSEPROXY_DASHBOARD:+traefik.http.routers.api.service=api@internal} # Exposes :8080/tcp
+            - ${REVERSEPROXY_DASHBOARD:+traefik.http.routers.api.middlewares=ip-whitelist@docker}
+            - ${REVERSEPROXY_DASHBOARD:+traefik.http.routers.api.entryPoints=websecure}
             # --- traefik Middleware: ipAllowList ---
             # 📖 HOWTO https://doc.traefik.io/traefik/reference/routing-configuration/http/middlewares/ipallowlist/
             - "traefik.http.middlewares.ip-whitelist.ipallowlist.sourcerange=${REVERSEPROXY_IP_ALLOWLIST:-127.0.0.1/32,::1/128}"
@@ -188,20 +191,22 @@ services:
             - --providers.file.watch=true
             - --serversTransport.insecureSkipVerify=true
             # -=[ HTTP Services ]=-
+            # --- Default HTTP
+            - --entryPoints.web.address=:80/tcp
+            - --entryPoints.web.http.redirections.entryPoint.to=websecure
+            - --entryPoints.web.http.redirections.entryPoint.scheme=https
+            - --entryPoints.web.http.redirections.entryPoint.permanent=true
+            # --- Default HTTPS
+            - --entryPoints.websecure.address=:443/tcp
+            - --entryPoints.websecure.http.tls=true
+            - --entrypoints.websecure.http.maxheaderbytes=5120
+            # --- Dashboard (Portainer)
             - --entryPoints.web-portainer.address=:9000/tcp
             - --entryPoints.web-portainer.http.redirections.entryPoint.to=websecure-portainer
             - --entryPoints.web-portainer.http.redirections.entryPoint.scheme=https
             - --entryPoints.web-portainer.http.redirections.entryPoint.permanent=true
             - --entryPoints.websecure-portainer.address=:9443/tcp
             - --entryPoints.websecure-portainer.http.tls=true
-            - --entryPoints.web.address=:80/tcp
-            - --entrypoints.web.http.maxheaderbytes=5120
-            - --entryPoints.web.http.redirections.entryPoint.to=websecure
-            - --entryPoints.web.http.redirections.entryPoint.scheme=https
-            - --entryPoints.web.http.redirections.entryPoint.permanent=true
-            - --entryPoints.websecure.address=:443/tcp
-            - --entryPoints.websecure.http.tls=true
-            - --entrypoints.websecure.http.maxheaderbytes=5120
             # -=[ Website ]=-
             - --entryPoints.php-xdebug.address=:9003/tcp
             # -=[ Mail Server ]=-
@@ -341,7 +346,6 @@ services:
         mem_limit: "${MARIADB_MEMORY:-2560m}"
         security_opt:
             - "no-new-privileges:true"
-        hostname: ${MARIADB_HOST:+${MARIADB_HOST}.${DOMAINNAME}}
         networks:
             - zion-mainframe
         expose:
@@ -386,6 +390,48 @@ services:
             - sslcerts-files:/certs:ro # :ro = read-only
             - database-files:/var/lib/mysql
             - "${HOST_PATH_LOGS:-./logs}/mariadb:/var/log/mariadb"
+
+    #-------------------
+    # 👨‍💻 DB Manager UI
+    #-------------------
+    db-manager:
+        profiles: [ "all", "webserver" ]
+        image: wodby/adminer:${DBMANAGER_VERSION:-latest}
+        platform: ${OS_PLATFORM:-linux/amd64}
+        container_name: ${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer
+        restart: on-failure:1
+        cpus: "${REVERSEPROXY_CPU:-0.5}"
+        mem_limit: "${REVERSEPROXY_MEMORY:-512m}"
+        #security_opt: # ⚠️ Do NOT limit for adminer to work!
+        hostname: ${DBMANAGER_HOST:+${DBMANAGER_HOST}.${DOMAINNAME}}
+        networks:
+            - zion-mainframe
+            - the-grid
+        expose:
+             - "8080/tcp"
+        labels:
+            # -=[ Servicealerting ]=-
+            - "telegram-notifier.monitor=${TELEGRAM_BOT_SERVICEALERTS_TOKEN:+true}"
+            - "telegram-notifier.chat-id=${TELEGRAM_BOT_SERVICEALERTS_CHATID:-}"
+            - "telegram-notifier.topic-id=${TELEGRAM_BOT_SERVICEALERTS_CHATTOPICID:-}"
+            - "telegram-notifier.service-uri=${DBMANAGER_HOST:+https://${DBMANAGER_HOST}.${DOMAINNAME}}"
+            # -=[ traefik Reverse Proxy : routing ON ]=-
+            - "traefik.enable=true"
+            - "traefik.docker.network=${NETWORK_HTTP_SERVICES:-loadbalance-http}"
+            # --- HTTP with SSL/TLS (:443) ---
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer-ssl.tls=true"
+            - ${USE_LETSENCRYPT:+traefik.http.routers.${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer-ssl.tls.certresolver=letsencrypt}
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer-ssl.entrypoints=websecure"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer-ssl.rule=Host(`${DBMANAGER_HOST}.${DOMAINNAME}`)"
+            - "traefik.http.routers.${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}adminer-ssl.middlewares=ip-whitelist@docker,compress-gzip"
+        environment:
+            # 📖 HOWTO https://github.com/wodby/adminer?tab=readme-ov-file#readme
+            - TZ=${TIMEZONE:-Europe/Zurich}
+            - ADMINER_DEFAULT_DB_DRIVER=server
+            - ADMINER_DEFAULT_DB_HOST=${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}mariadb
+            - ADMINER_DEFAULT_DB_NAME=${DATABASE_NAME:-}
+            - ADMINER_DESIGN=${DBMANAGER_DESIGN:-pappu687}
+            - ADMINER_PLUGINS=${DBMANAGER_PLUGINS:-}
 
     #--------------------------------------------------
     # 📧 Mail Server (outgoing SMTP only, for sendmail)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -421,7 +421,7 @@ services:
         environment:
             # 📖 HOWTO https://github.com/wodby/adminer?tab=readme-ov-file#readme
             - TZ=${TIMEZONE:-Europe/Zurich}
-            - ADMINER_DEFAULT_DB_DRIVER=server
+            - ADMINER_DEFAULT_DB_DRIVER=mysql
             - ADMINER_DEFAULT_DB_HOST=${COMPOSE_PROJECT_NAME:+${COMPOSE_PROJECT_NAME}-}mariadb
             - ADMINER_DEFAULT_DB_NAME=${DATABASE_NAME:-}
             - ADMINER_DESIGN=${DBMANAGER_DESIGN:-pappu687}


### PR DESCRIPTION
This PR adds a Web UI-based Database Manager based on the wodby/adminer Docker image. This allows – with IP-restricted access controls - to connect to & conduct Database operations to the existing `mariadb` db Docker service.