### PR TITLE
Adds support of new ENVs for q-IRC Quizbot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,7 @@ LETSENCRYPT_CASERVER=
 # 🌐 Apache-PHP Website
 HTTP_PORT=80
 HTTP_PORT_SSL=443
-# Leave `WEBSITE_IS_DEVELOPMENT` EMPTY on production!
+# ℹ️ Leave `WEBSITE_IS_DEVELOPMENT` EMPTY on production!
 WEBSITE_IS_DEVELOPMENT=
 WEBSITE_STRIP_WWW=true
 WEBSITE_ROOT_DIR=/var/www
@@ -170,7 +170,7 @@ XDEBUG_PORT=
 # 💽 MariaDB Database
 MARIADB_VERSION=latest
 MARIADB_PORT=3306
-# Locally, you may disable ROOT_PASSWORD using 'yes'
+# [💡] Locally, you may disable ROOT_PASSWORD using 'yes'
 MARIADB_DISABLE_ROOT_PASSWORD=no
 MARIADB_ROOT_PASSWORD=
 DATABASE_NAME=zooomclan
@@ -188,13 +188,13 @@ DBMANAGER_PLUGINS="tables-filter tinymce"
 # 📧 Mail Server (SMTP)
 MAILSERVER_HOST=smtp
 MAILSERVER_HOST_INTERNAL=localhost-docker-smtp
-# Logging: Use 'debug' for debugging ONLY - otherwise 'info' (lowercase matters!)
+# [💡] Logging: Use 'debug' for debugging ONLY - otherwise 'info' (lowercase matters!)
 MAILSERVER_LOGLEVEL=info
 MAILSERVER_EMAIL_MAXSIZE=10240000
 MAILSERVER_PORT_SMTP=587
 MAILSERVER_PORT_SMTP_SSL=465
 MAILSERVER_PORT_SMTP_INTERNAL=25
-# Format for `SMTP_RELAY_SERVER` = [host]:${SMTP_RELAY_PORT:-465}
+# [💡] Format for `SMTP_RELAY_SERVER` = [host]:${SMTP_RELAY_PORT:-465}
 SMTP_RELAY_PORT=
 SMTP_RELAY_SERVER=
 SMTP_RELAY_USER=
@@ -207,12 +207,17 @@ IRC_PORT=6667
 IRC_PORT_SSL=6697
 
 # 🧩 Quizbot (for IRC)
-IRC_QUIZBOT_PASSWORD=
 IRC_QUIZBOT_ADMINS=nickname,barbara
+IRC_QUIZBOT_SERVER=${IRC_HOST:+${IRC_HOST}.${DOMAINNAME}}
+IRC_QUIZBOT_PORT=${IRC_PORT:-6667}
+IRC_QUIZBOT_JOIN=quiz
+IRC_QUIZBOT_NICKNAME=quizhans
+# ℹ️ (Optional) IRC NickServ Auth Password
+IRC_QUIZBOT_PASSWORD=
 IRC_QUIZBOT_DEBUG=${WEBSITE_IS_DEVELOPMENT:-false}
 
 # 🔑 KeePass DB (SFTP)
-# [💡] Do not use Port 22 (default) --> may conflict with ssh!
+# ℹ️ Do not use Port 22 (default) --> may conflict with ssh!
 KEEPASS_HOST=pw
 KEEPASS_PORT_SFTP=2222
 KEEPASS_SFTP_USER=keepass
@@ -221,7 +226,7 @@ KEEPASS_SFTP_PASSWORD=
 # 🕹️ Quake 3 Arena-Server
 QUAKE3_HOST=quake
 QUAKE3_PORT=27960
-# `QUAKE3_RCON_PASSWORD` is required to issue remote console commands
+# ℹ️ `QUAKE3_RCON_PASSWORD` is required to issue remote console commands
 QUAKE3_RCON_PASSWORD=RequiredButChangeMe!
 
 # 📈 Stockticker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -543,7 +543,6 @@ services:
         hostname: ${IRC_HOST:+${IRC_HOST}.${DOMAINNAME}}
         networks:
             - information-superhighway
-            - clown-protocol
         expose:
             - "6667/tcp" # ℹ️ Unencrypted default IRC Port
             - "6697/tcp" # ℹ️ SSL/TLS encrypted IRC Port
@@ -617,7 +616,7 @@ services:
         security_opt:
             - "no-new-privileges:true"
         networks:
-            - clown-protocol
+            - information-superhighway
         labels:
             # -=[ Servicealerting ]=-
             - "telegram-notifier.monitor=${TELEGRAM_BOT_SERVICEALERTS_TOKEN:+true}"
@@ -629,6 +628,10 @@ services:
         environment:
             - TZ=${TIMEZONE:-Europe/Zurich}
             - DEBIAN_FRONTEND=noninteractive
+            - IRC_SERVER=${IRC_QUIZBOT_SERVER}
+            - IRC_SERVER_PORT=${IRC_QUIZBOT_PORT}
+            - CHANNEL=${IRC_QUIZBOT_JOIN:-quiz}
+            - NICKNAME=${IRC_QUIZBOT_NICKNAME:-quizhans}
             - NICKSERV_PASSWORD=${IRC_QUIZBOT_PASSWORD:-false}
             - BOTMASTERS=${IRC_QUIZBOT_ADMINS:-nickname,barbara}
             - VERBOSE=${IRC_QUIZBOT_DEBUG:-false}
@@ -793,9 +796,6 @@ services:
 #==============================
 networks:
     zion-mainframe:
-        internal: true
-        driver: bridge
-    clown-protocol:
         internal: true
         driver: bridge
     the-grid:

--- a/resources/python/irc-quizbot/service-setup.sh
+++ b/resources/python/irc-quizbot/service-setup.sh
@@ -53,7 +53,7 @@ else
 fi
 
 
-########## If available: use custom quizbot config files ##########
+###### (If available) Use mapped custom config file overrides #######
 if [ -f "/home/q/config.py" ]; then
   cp -f /home/q/config.py $APP_DIR/config.py
 fi


### PR DESCRIPTION
This helps that q-Bot can connect to the right internal IRC-Server.

- `IRC_QUIZBOT_SERVER` : IRC server address
- `IRC_QUIZBOT_PORT`: port to connect to
- `IRC_QUIZBOT_JOIN`: Channel to join on
- `IRC_QUIZBOT_NICKNAME`: Nickname to use